### PR TITLE
chore(Dockerfile): update to ubuntu-slim:0.4

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/google_containers/ubuntu-slim:0.3
+FROM gcr.io/google_containers/ubuntu-slim:0.4
 
 ENV TERM=xterm
 


### PR DESCRIPTION
https://quay.io/repository/aledbf/ubuntu-slim?tab=tags shows the reduction in vulns. Nothing else changed

Note that gcr is still the real source for the image
