### PR TITLE
feat(Makefile): add --no-cache flag to `docker build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ IMAGE_PREFIX ?= deis
 IMAGE := ${REGISTRY}${IMAGE_PREFIX}/base:${VERSION}
 
 build:
-	docker build -t ${IMAGE} rootfs
+	docker build --no-cache -t ${IMAGE} rootfs
 
 push: build
 	docker push ${IMAGE}


### PR DESCRIPTION
This flag ensures we have the latest releases of bash, curl, net-tools and procops in the container.
