### PR TITLE
fix(Dockerfile): upgrade all packages on build

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -3,13 +3,14 @@ FROM gcr.io/google_containers/ubuntu-slim:0.4
 ENV TERM=xterm
 
 # disable source repos (speeds up apt-get update)
-RUN sed -i -e 's/^deb-src/#deb-src/' /etc/apt/sources.list && \
-apt-get update && \
-apt-get install -y \
-	bash \
-	curl \
-	net-tools \
-	procps && \
-	apt-get clean && \
-	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/man /usr/share/doc && \
-bash -c "mkdir -p /usr/share/man/man{1..8}"
+RUN sed -i -e 's/^deb-src/#deb-src/' /etc/apt/sources.list \
+	&& apt-get update \
+	&& apt-get upgrade -y \
+	&& apt-get install -y \
+		bash \
+		curl \
+		net-tools \
+		procps \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/man /usr/share/doc \
+	&& bash -c "mkdir -p /usr/share/man/man{1..8}"


### PR DESCRIPTION
It's not guaranteed that upstream will upgrade all of the packages
within a reasonable timeframe. Therefore, when we build we should
enforce an upgrade.

It's either this or using ubuntu:16.04 directly, which at this point I'm more prone to use given that Docker tends to keep their image more up to date. Anyways I'd figure we should stay the course and use ubuntu-slim until we've fixed this issue.
