### PR TITLE
fix(Dockerfile): pin working locales package

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -4,6 +4,8 @@ ENV TERM=xterm
 
 # disable source repos (speeds up apt-get update)
 RUN sed -i -e 's/^deb-src/#deb-src/' /etc/apt/sources.list && \
+    export DEBIAN_FRONTEND=noninteractive && \
+    apt-mark hold locales && \
     apt-get update && \
     apt-get upgrade -y --no-install-recommends && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
The updated `locales` package fails to install with an error about not finding `locale-gen`. However, the [ubuntu-slim 0.5 PR](https://github.com/deis/docker-base/pull/19) passed, so the newer `locales` package must have been made available after that. This pins the working `locales_2.23-0ubuntu3_all.deb` package already in the base image to prevent the following breakage:

``` shell
The following packages will be upgraded:
  locales
1 upgraded, 0 newly installed, 0 to remove and 3 not upgraded.
Need to get 3214 kB of archives.
After this operation, 0 B of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 locales all 2.23-0ubuntu4 [3214 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 3214 kB in 2s (1296 kB/s)
(Reading database ... 4107 files and directories currently installed.)
Preparing to unpack .../locales_2.23-0ubuntu4_all.deb ...
Unpacking locales (2.23-0ubuntu4) over (2.23-0ubuntu3) ...
Setting up locales (2.23-0ubuntu4) ...
/var/lib/dpkg/info/locales.postinst: 64: /var/lib/dpkg/info/locales.postinst: locale-gen: not found
dpkg: error processing package locales (--configure):
 subprocess installed post-installation script returned error exit status 127
Errors were encountered while processing:
 locales
```
