### PR TITLE
ref(Dockerfile): use official ubuntu image instead of ubuntu-slim

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/google_containers/ubuntu-slim:0.5
+FROM ubuntu:16.04
 
 ENV TERM=xterm
 


### PR DESCRIPTION
time and time again ubuntu-slim is out of date and requires updating/releasing a new semver release
for a security patch. The latest security vulnerability is `apt` which has
[already been fixed](https://github.com/docker-library/official-images/pull/2449) nearly a month ago on the official image.

Switching back to the "official" ubuntu image allows us to stay up to date with the latest security
patches.