### PR TITLE
chore(*): update for upstream Ubuntu fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A slimmed-down Ubuntu-based container image used as the basis of [Deis Workflow]
 Start your Dockerfile with this line:
 
 ```
-FROM quay.io/deis/base:v0.3.6
+FROM quay.io/deis/base:v0.3.7
 ```
 
 There isn't a `:latest` tag, because tagged container images should be immutable.
@@ -18,18 +18,18 @@ The latest deis/base image is available at:
 
 * [Quay.io][]
   ```
-  docker pull quay.io/deis/base:v0.3.6
+  docker pull quay.io/deis/base:v0.3.7
   ```
 
 * [Docker Hub][]
   ```
-  docker pull deis/base:v0.3.6
+  docker pull deis/base:v0.3.7
   ```
 
 ## Updating Downstream Images
 
 Lots of Workflow components rely on deis/base. In order to update the downstream repos with the
-new image, run `OLD_VERSION="v0.3.6" NEW_VERSION="v0.3.7" ./_scripts/make-prs.sh`. This will
+new image, run `OLD_VERSION="v0.3.7" NEW_VERSION="v0.3.8" ./_scripts/make-prs.sh`. This will
 clone all the downstream repos in /tmp, change the image, commit the change and push it to a new
 branch. The script will then open a browser window to make a PR against master for that repo.
 

--- a/_scripts/make-prs.sh
+++ b/_scripts/make-prs.sh
@@ -4,8 +4,8 @@ ARCH="$(uname)"
 ORG="deis"
 REPOS=${REPOS:-builder controller clusterator docker-go-dev dockerbuilder e2e-runner fluentd logbomb logger minio monitor nsq postgres redis steward steward-cf registry-token-refresher router workflow-manager workflow-migration}
 
-OLD_VERSION=${OLD_VERSION:-v0.3.6}
-NEW_VERSION=${NEW_VERSION:-v0.3.7}
+OLD_VERSION=${OLD_VERSION:-v0.3.7}
+NEW_VERSION=${NEW_VERSION:-v0.3.8}
 
 for repo in $REPOS; do
     echo "cloning $USER/$repo to /tmp/$repo..."

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -5,7 +5,6 @@ ENV TERM=xterm
 # disable source repos (speeds up apt-get update)
 RUN sed -i -e 's/^deb-src/#deb-src/' /etc/apt/sources.list && \
     export DEBIAN_FRONTEND=noninteractive && \
-    apt-mark hold locales && \
     apt-get update && \
     apt-get upgrade -y --no-install-recommends && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
I built this manually and uploaded it to quay.io, where the virus scanner shows only 20 medium-level vulnerabilities now.

See deis/slugrunner#67.